### PR TITLE
FIX: Date picker UTC consistency for multi-day ranges

### DIFF
--- a/src/renderer/components/UsageDashboard.tsx
+++ b/src/renderer/components/UsageDashboard.tsx
@@ -125,16 +125,18 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
               } else if (range.days === 0) {
                 // Today option - show only today's data (UTC-based)
                 const now = new Date();
-                const start = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
-                const end = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
-                onDateRangeChange(start, end);
+                const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+                onDateRangeChange(todayUTC, todayUTC);
               } else {
                 // Multi-day ranges (UTC-based)
                 const now = new Date();
-                const startDate = subDays(now, range.days);
-                const start = new Date(Date.UTC(startDate.getFullYear(), startDate.getMonth(), startDate.getDate()));
-                const end = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
-                onDateRangeChange(start, end);
+                // Get current UTC date at midnight
+                const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+                // Calculate start date by subtracting days from UTC date
+                const startUTC = new Date(todayUTC);
+                startUTC.setUTCDate(todayUTC.getUTCDate() - range.days);
+                
+                onDateRangeChange(startUTC, todayUTC);
               }
             }}
             className="btn interactive-bounce px-3 py-1 text-sm bg-[var(--bg-tertiary)] text-[var(--text-secondary)] rounded-md hover:bg-[var(--color-hover)] theme-transition"
@@ -149,7 +151,7 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
           onChange={(date) => {
             if (date) {
               // Create UTC date to match string-based filtering
-              const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+              const utcDate = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
               onDateRangeChange(utcDate, endDate);
             }
           }}
@@ -161,7 +163,7 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
           onChange={(date) => {
             if (date) {
               // Create UTC date to match string-based filtering
-              const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+              const utcDate = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
               onDateRangeChange(startDate, utcDate);
             }
           }}
@@ -303,10 +305,10 @@ const UsageDashboard: React.FC = () => {
   // State for date range filtering - default to today (UTC-based)
   const [dateRange, setDateRange] = useState(() => {
     const now = new Date();
-    const utcDate = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+    const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
     return {
-      start: utcDate,
-      end: utcDate,
+      start: todayUTC,
+      end: todayUTC,
     };
   });
   
@@ -597,9 +599,9 @@ const UsageDashboard: React.FC = () => {
           onDateRangeChange={(start, end) => {
             if (start === null && end === null) {
               // ALL option - use earliest data date (UTC-based)
-              const allStart = new Date(Date.UTC(earliestDataDate.getFullYear(), earliestDataDate.getMonth(), earliestDataDate.getDate()));
+              const allStart = new Date(Date.UTC(earliestDataDate.getUTCFullYear(), earliestDataDate.getUTCMonth(), earliestDataDate.getUTCDate()));
               const now = new Date();
-              const allEnd = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+              const allEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
               setDateRange({ start: allStart, end: allEnd });
             } else if (start && end) {
               setDateRange({ start, end });


### PR DESCRIPTION
## Summary
This PR fixes date picker issues for 7-day and 30-day ranges by ensuring all date calculations use UTC dates consistently.

## Problem
When selecting 7-day or 30-day ranges, the date calculations could be off by one day depending on the user's timezone. This happened because:
- We were using local date methods (`getFullYear()`, `getMonth()`, `getDate()`) on dates that could be in different days when converted to UTC
- The `subDays()` function returns a date/time in the local timezone, which could map to a different UTC date

## Solution
- Use `getUTC*` methods consistently throughout all date calculations
- Calculate multi-day ranges by working directly with UTC dates
- Ensure Today, 7 Days, 30 Days, and All options all use the same UTC-based approach

## Changes
- Updated date range calculations in `DateRangePicker` component
- Fixed Today option to use UTC dates
- Fixed multi-day ranges (7 days, 30 days) to calculate from UTC midnight
- Fixed ALL option to use UTC dates
- Updated manual date picker handlers to use UTC methods

## Testing
- Tested date calculations work correctly regardless of user's timezone
- Verified that date ranges now correctly include/exclude data based on UTC dates
- Confirmed TypeScript compilation passes

## Impact
Users in timezones different from UTC will now see correct date ranges without off-by-one errors.