### PR TITLE
UI: Update date range labels from numeric to descriptive terms

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,40 @@
+2025-07-20 16:08:49 +08 - UI UPDATE: Changed date range labels from numeric to descriptive terms
+- SCOPE: All language translation files updated for improved clarity
+- CHANGE TYPE: UI/UX improvement for better user understanding
+
+DATE RANGE LABEL UPDATES:
+• "7 Days" → "Weekly" (English)
+• "7 Tage" → "Wöchentlich" (German)
+• "7 Días" → "Semanal" (Spanish) - Also fixed "TODO" placeholder to "Todo el Tiempo"
+• "7 Jours" → "Hebdomadaire" (French)
+• "7日間" → "週間" (Japanese)
+• "7天" → "每周" (Chinese)
+
+• "30 Days" → "Monthly" (English)
+• "30 Tage" → "Monatlich" (German)
+• "30 Días" → "Mensual" (Spanish)
+• "30 Jours" → "Mensuel" (French)
+• "30日間" → "月間" (Japanese)
+• "30天" → "每月" (Chinese)
+
+• "ALL" → "All Time" (English)
+• "ALLE" → "Gesamtzeitraum" (German)
+• "TODO" → "Todo el Tiempo" (Spanish) - Fixed placeholder issue
+• "TOUT" → "Tout le Temps" (French)
+• "全期間" → "全期間" (Japanese - kept same as already appropriate)
+• "全部" → "全部时间" (Chinese)
+
+AFFECTED FILES:
+- src/renderer/i18n/locales/en.json
+- src/renderer/i18n/locales/de.json
+- src/renderer/i18n/locales/es.json
+- src/renderer/i18n/locales/fr.json
+- src/renderer/i18n/locales/ja.json
+- src/renderer/i18n/locales/zh.json
+
+IMPACT: These translations are used in UsageDashboard.tsx and ProjectDetailView.tsx
+No code changes required - only translation file updates.
+
 2025-06-29 23:45:12 +08 - VERSION 1.0.1 RELEASE PREPARATION: Complete feature branch ready for merge
 - SUMMARY: Major UX improvements, critical bug fixes, and comprehensive internationalization
 - SCOPE: Session duration fixes, translation completeness, chart UX improvements, version consistency

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+2025-07-20 00:15 PST - Implement proper monthly date calculations with month boundary handling
+- Fixed date range calculation to properly handle different month lengths (28/29/30/31 days)
+- Monthly option now uses setUTCMonth() which automatically adjusts for month boundaries
+- Example: Selecting "Monthly" on March 31 correctly shows data from Feb 28/29, not March 3
+- Weekly remains as 7-day period but calculation is clearer (last 6 days + today)
+- All calculations remain UTC-based for timezone consistency
+- Updated component to use type-based range selection instead of numeric days
+
 2025-07-20 16:08:49 +08 - UI UPDATE: Changed date range labels from numeric to descriptive terms
 - SCOPE: All language translation files updated for improved clarity
 - CHANGE TYPE: UI/UX improvement for better user understanding

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,7 @@
-2025-07-20 00:15 PST - Implement proper monthly date calculations with month boundary handling
-- Fixed date range calculation to properly handle different month lengths (28/29/30/31 days)
-- Monthly option now uses setUTCMonth() which automatically adjusts for month boundaries
-- Example: Selecting "Monthly" on March 31 correctly shows data from Feb 28/29, not March 3
-- Weekly remains as 7-day period but calculation is clearer (last 6 days + today)
+2025-07-20 00:15 PST - Implement intuitive date range calculations for Weekly and Monthly
+- Monthly option now shows current month from 1st to today (e.g., July 1-20, not June 20-July 20)
+- This is more intuitive and matches user expectations for "monthly" data
+- Weekly remains as last 7 days including today
 - All calculations remain UTC-based for timezone consistency
 - Updated component to use type-based range selection instead of numeric days
 

--- a/src/renderer/components/UsageDashboard.tsx
+++ b/src/renderer/components/UsageDashboard.tsx
@@ -125,16 +125,18 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
               } else if (range.days === 0) {
                 // Today option - show only today's data (UTC-based)
                 const now = new Date();
-                const start = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
-                const end = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
-                onDateRangeChange(start, end);
+                const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+                onDateRangeChange(todayUTC, todayUTC);
               } else {
                 // Multi-day ranges (UTC-based)
                 const now = new Date();
-                const startDate = subDays(now, range.days);
-                const start = new Date(Date.UTC(startDate.getFullYear(), startDate.getMonth(), startDate.getDate()));
-                const end = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
-                onDateRangeChange(start, end);
+                // Get current UTC date at midnight
+                const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+                // Calculate start date by subtracting days from UTC date
+                const startUTC = new Date(todayUTC);
+                startUTC.setUTCDate(todayUTC.getUTCDate() - range.days);
+                
+                onDateRangeChange(startUTC, todayUTC);
               }
             }}
             className="btn interactive-bounce px-3 py-1 text-sm bg-[var(--bg-tertiary)] text-[var(--text-secondary)] rounded-md hover:bg-[var(--color-hover)] theme-transition"
@@ -149,7 +151,7 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
           onChange={(date) => {
             if (date) {
               // Create UTC date to match string-based filtering
-              const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+              const utcDate = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
               onDateRangeChange(utcDate, endDate);
             }
           }}
@@ -161,7 +163,7 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
           onChange={(date) => {
             if (date) {
               // Create UTC date to match string-based filtering
-              const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+              const utcDate = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
               onDateRangeChange(startDate, utcDate);
             }
           }}
@@ -303,10 +305,10 @@ const UsageDashboard: React.FC = () => {
   // State for date range filtering - default to today (UTC-based)
   const [dateRange, setDateRange] = useState(() => {
     const now = new Date();
-    const utcDate = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+    const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
     return {
-      start: utcDate,
-      end: utcDate,
+      start: todayUTC,
+      end: todayUTC,
     };
   });
   
@@ -597,9 +599,9 @@ const UsageDashboard: React.FC = () => {
           onDateRangeChange={(start, end) => {
             if (start === null && end === null) {
               // ALL option - use earliest data date (UTC-based)
-              const allStart = new Date(Date.UTC(earliestDataDate.getFullYear(), earliestDataDate.getMonth(), earliestDataDate.getDate()));
+              const allStart = new Date(Date.UTC(earliestDataDate.getUTCFullYear(), earliestDataDate.getUTCMonth(), earliestDataDate.getUTCDate()));
               const now = new Date();
-              const allEnd = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+              const allEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
               setDateRange({ start: allStart, end: allEnd });
             } else if (start && end) {
               setDateRange({ start, end });

--- a/src/renderer/components/UsageDashboard.tsx
+++ b/src/renderer/components/UsageDashboard.tsx
@@ -106,10 +106,10 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
 }) => {
   const { t } = useTranslation();
   const presetRanges = [
-    { label: t('dateRange.today'), days: 0 },
-    { label: t('dateRange.7Days'), days: 7 },
-    { label: t('dateRange.30Days'), days: 30 },
-    { label: t('dateRange.all'), days: null },
+    { label: t('dateRange.today'), type: 'today' as const },
+    { label: t('dateRange.7Days'), type: 'weekly' as const },
+    { label: t('dateRange.30Days'), type: 'monthly' as const },
+    { label: t('dateRange.all'), type: 'all' as const },
   ];
 
   return (
@@ -119,24 +119,38 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
           <button
             key={range.label}
             onClick={() => {
-              if (range.days === null) {
-                // ALL option - will be handled by parent component
-                onDateRangeChange(null, null); // Signal to use earliest data
-              } else if (range.days === 0) {
-                // Today option - show only today's data (UTC-based)
-                const now = new Date();
-                const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-                onDateRangeChange(todayUTC, todayUTC);
-              } else {
-                // Multi-day ranges (UTC-based)
-                const now = new Date();
-                // Get current UTC date at midnight
-                const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-                // Calculate start date by subtracting days from UTC date
-                const startUTC = new Date(todayUTC);
-                startUTC.setUTCDate(todayUTC.getUTCDate() - range.days);
-                
-                onDateRangeChange(startUTC, todayUTC);
+              const now = new Date();
+              const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+              
+              switch (range.type) {
+                case 'all':
+                  // All Time option - show all data
+                  onDateRangeChange(null, null);
+                  break;
+                  
+                case 'today':
+                  // Today option - show only today's data (UTC-based)
+                  onDateRangeChange(todayUTC, todayUTC);
+                  break;
+                  
+                case 'weekly': {
+                  // Weekly option - last 7 days (UTC-based)
+                  const weekStart = new Date(todayUTC);
+                  weekStart.setUTCDate(todayUTC.getUTCDate() - 6); // 7 days including today
+                  onDateRangeChange(weekStart, todayUTC);
+                  break;
+                }
+                  
+                case 'monthly': {
+                  // Monthly option - properly handle month boundaries
+                  const monthStart = new Date(todayUTC);
+                  // Go back one month, accounting for different month lengths
+                  monthStart.setUTCMonth(todayUTC.getUTCMonth() - 1);
+                  // If the day doesn't exist in the previous month (e.g., March 31 -> Feb 31),
+                  // it automatically adjusts to the last valid day (e.g., Feb 28/29)
+                  onDateRangeChange(monthStart, todayUTC);
+                  break;
+                }
               }
             }}
             className="btn interactive-bounce px-3 py-1 text-sm bg-[var(--bg-tertiary)] text-[var(--text-secondary)] rounded-md hover:bg-[var(--color-hover)] theme-transition"

--- a/src/renderer/components/UsageDashboard.tsx
+++ b/src/renderer/components/UsageDashboard.tsx
@@ -142,12 +142,8 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
                 }
                   
                 case 'monthly': {
-                  // Monthly option - properly handle month boundaries
-                  const monthStart = new Date(todayUTC);
-                  // Go back one month, accounting for different month lengths
-                  monthStart.setUTCMonth(todayUTC.getUTCMonth() - 1);
-                  // If the day doesn't exist in the previous month (e.g., March 31 -> Feb 31),
-                  // it automatically adjusts to the last valid day (e.g., Feb 28/29)
+                  // Monthly option - show current month from 1st to today
+                  const monthStart = new Date(Date.UTC(todayUTC.getUTCFullYear(), todayUTC.getUTCMonth(), 1));
                   onDateRangeChange(monthStart, todayUTC);
                   break;
                 }

--- a/src/renderer/i18n/locales/de.json
+++ b/src/renderer/i18n/locales/de.json
@@ -58,9 +58,9 @@
   "dateRange": {
     "title": "Datumsbereich",
     "today": "Heute",
-    "7Days": "7 Tage",
-    "30Days": "30 Tage",
-    "all": "ALLE",
+    "7Days": "Wöchentlich",
+    "30Days": "Monatlich",
+    "all": "Gesamtzeitraum",
     "to": "bis",
     "last7Days": "Letzten 7 Tage",
     "last30Days": "Letzten 30 Tage",

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -58,9 +58,9 @@
   "dateRange": {
     "title": "Date Range",
     "today": "Today",
-    "7Days": "7 Days",
-    "30Days": "30 Days",
-    "all": "ALL",
+    "7Days": "Weekly",
+    "30Days": "Monthly",
+    "all": "All Time",
     "to": "to",
     "last7Days": "Last 7 Days",
     "last30Days": "Last 30 Days",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -58,9 +58,9 @@
   "dateRange": {
     "title": "Rango de Fechas",
     "today": "Hoy",
-    "7Days": "7 Días",
-    "30Days": "30 Días",
-    "all": "TODO",
+    "7Days": "Semanal",
+    "30Days": "Mensual",
+    "all": "Todo el Tiempo",
     "to": "hasta",
     "last7Days": "Últimos 7 Días",
     "last30Days": "Últimos 30 Días",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -58,9 +58,9 @@
   "dateRange": {
     "title": "Plage de Dates",
     "today": "Aujourd'hui",
-    "7Days": "7 Jours",
-    "30Days": "30 Jours",
-    "all": "TOUT",
+    "7Days": "Hebdomadaire",
+    "30Days": "Mensuel",
+    "all": "Tout le Temps",
     "to": "à",
     "last7Days": "7 Derniers Jours",
     "last30Days": "30 Derniers Jours",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -58,8 +58,8 @@
   "dateRange": {
     "title": "期間",
     "today": "今日",
-    "7Days": "7日間",
-    "30Days": "30日間",
+    "7Days": "週間",
+    "30Days": "月間",
     "all": "全期間",
     "to": "から",
     "last7Days": "過去7日間",

--- a/src/renderer/i18n/locales/zh.json
+++ b/src/renderer/i18n/locales/zh.json
@@ -58,9 +58,9 @@
   "dateRange": {
     "title": "日期范围",
     "today": "今天",
-    "7Days": "7天",
-    "30Days": "30天",
-    "all": "全部",
+    "7Days": "每周",
+    "30Days": "每月",
+    "all": "全部时间",
     "to": "至",
     "last7Days": "最近7天",
     "last30Days": "最近30天",


### PR DESCRIPTION
## Summary
- Rename date range options for better clarity:
  - "7 Days" → "Weekly"
  - "30 Days" → "Monthly"  
  - "ALL" → "All Time"
- Implement intuitive monthly calculations

## Changes
1. **Updated all 6 translation files** with more intuitive labels
   - Fixed Spanish translation that had "TODO" placeholder
2. **Monthly now shows current month from 1st to today**:
   - Example: On July 20, shows July 1-20 (not June 20-July 20)
   - More intuitive and matches user expectations
   - Weekly remains as last 7 days including today
3. **Refactored date range logic** to use type-based selection instead of numeric days
4. **All calculations remain UTC-based** for timezone consistency

## Test Plan
- [x] TypeScript compilation passes
- [x] Monthly shows current month from 1st
- [ ] Test at month boundaries (e.g., on the 1st)
- [ ] Verify translations display correctly in all languages